### PR TITLE
Fix: Update assertion in test_upload_to_s3_compressed_s3_error_cleanup

### DIFF
--- a/tests/test_cognito_exporter.py
+++ b/tests/test_cognito_exporter.py
@@ -84,7 +84,7 @@ class TestCognitoExporterS3Upload(unittest.TestCase):
         with self.assertRaises(ClientError) as context:
             self.exporter.upload_to_s3(bucket=bucket_name, key=s3_key, compress=True)
 
-        self.assertTrue(str(context.exception), "Mock S3 error")
+        self.assertIn("Mock S3 error", str(context.exception))
 
         self.exporter.s3_client.upload_file.assert_called_once_with(
             self.test_output_gz_filename,


### PR DESCRIPTION
The assertion in test_upload_to_s3_compressed_s3_error_cleanup was changed from `self.assertTrue(str(context.exception), "Mock S3 error")` to `self.assertIn("Mock S3 error", str(context.exception))`.

This ensures that the test verifies the content of the error message rather than just its truthiness, providing a more accurate and robust test for the S3 error handling during compressed uploads.

## Summary by Sourcery

Tests:
- Replace `assertTrue` with `assertIn` in `test_upload_to_s3_compressed_s3_error_cleanup` to ensure the exception message contains "Mock S3 error"