### PR TITLE
Add dev tool dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ packages = [{include = "cognito_attribute_exporter"}]
 [tool.poetry.dependencies]
 python = "^3.10"
 boto3 = "^1.34.0" # Using a recent version
+botocore = "^1.34.0" # Explicitly required for tests
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ boto3 = "^1.34.0" # Using a recent version
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.5"
+black = "^24.4.2"
+flake8 = "^7.0.0"
 
 [tool.poetry.scripts]
 cognito-export = "cognito_attribute_exporter.cognito_exporter:main"
@@ -21,3 +23,11 @@ cognito-dedup = "cognito_attribute_exporter.cognito_csv_deduplicator:main"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.black]
+line-length = 88
+target-version = ['py310']
+
+[tool.flake8]
+max-line-length = 88
+extend-ignore = ['E203', 'W503']


### PR DESCRIPTION
## Summary
- include `black` and `flake8` dev dependencies
- configure formatting & linting tools in `pyproject.toml`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'botocore')*

------
https://chatgpt.com/codex/tasks/task_e_684839f083688332873c1447dd23155c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added code formatting and linting tools with standardized style settings for development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->